### PR TITLE
Fix footer links

### DIFF
--- a/website/src/components/Page/Footer.js
+++ b/website/src/components/Page/Footer.js
@@ -21,8 +21,8 @@ export default function Footer() {
                 <h2>General</h2>
                 <ul>
                     <a href="/"><li>Home</li></a>
-                    <a href="/about"><li>About</li></a>
-                    <a href="/projects"><li>Projects</li></a>
+                    <a href="/#/about"><li>About</li></a>
+                    <a href="/#/projects"><li>Projects</li></a>
                     {/* <a href="/contact"><li>Contact</li></a> */}
                 </ul>
             </div>


### PR DESCRIPTION
Previously, the footer links for "About" and "Projects" were broken.
This adds "#" to the path to make them work. But maybe we should restructure so it doesn't need a "#"?

Fixes #28 