### PR TITLE
Fix banner overflow on mobile

### DIFF
--- a/src/components/Page/Header.css
+++ b/src/components/Page/Header.css
@@ -6,6 +6,7 @@
   display: flex;
   justify-content: center;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .header .title {
@@ -27,7 +28,12 @@
 
 .header img {
   max-width: 100%;
-  transform: scale(2.5);
-  margin-top: 3rem;
-  margin-bottom: 3rem;
+  max-height: 100%;
+  margin: 0 0 1rem 0;
+}
+
+@media only screen and (max-width: 700px) {
+  .header img {
+    transform: scale(1.5);
+  }
 }


### PR DESCRIPTION
The new banner was causing some issues on mobile: https://blueprintatuci.slack.com/archives/C011JNP5S1W/p1604288737000700

This PR fixes the responsiveness and also centers the banner on desktop
![image](https://user-images.githubusercontent.com/29494270/97840399-c3c4e680-1c98-11eb-8b05-fd96ed2ea338.png)
